### PR TITLE
Add Docker support and fix enterprise permissions documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+.git
+.github
+.vscode
+.env
+*.env
+*.log
+dist
+*.tgz
+.DS_Store 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0] - 2025-04-01
+
+### Added
+- Docker support for easier deployment
+  - Added Dockerfile using Node.js 18 Alpine
+  - Created .dockerignore to exclude unnecessary files
+  - Added docker-compose.yml for simplified deployment
+  - Configured to run in HTTP/SSE transport mode by default
+- User management API for GitHub Enterprise
+  - Added listUsers: Retrieve all users in GitHub Enterprise
+  - Added getUser: Get details of a specific user
+  - Added createUser: Create a new user (Enterprise only)
+  - Added updateUser: Update user information
+  - Added deleteUser: Delete a user
+  - Added suspendUser/unsuspendUser: Suspend and unsuspend users
+  - Added listUserOrgs: List organizations a user belongs to
+
+### Changed
+- Updated README with Docker installation and usage instructions
+- Improved documentation for enterprise-specific tools to clarify site_admin requirements
+
+## [1.1.0] - 2025-03-25
+
+- Initial public release 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+# Copy dependency files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy application code
+COPY . .
+
+# Build TypeScript
+RUN npm run build
+
+# Set environment variables
+ENV PORT=3000
+ENV NODE_ENV=production
+
+# Expose port
+EXPOSE 3000
+
+# Run application
+CMD ["node", "dist/index.js", "--transport", "http"] 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project is primarily designed for GitHub Enterprise Server environments, bu
 - Manage issues and pull requests
 - Repository management (create, update, delete)
 - GitHub Actions workflows management
+- User management (list, create, update, delete, suspend/unsuspend users)
 - Access enterprise statistics
 - Enhanced error handling and user-friendly response formatting
 
@@ -29,6 +30,57 @@ This project is primarily designed for GitHub Enterprise Server environments, bu
 - Node.js 18 or higher
 - Access to a GitHub Enterprise instance
 - Personal Access Token (PAT)
+
+### Docker Installation and Setup
+
+#### Option 1: Running with Docker
+
+1. Build the Docker image:
+```bash
+docker build -t github-enterprise-mcp .
+```
+
+2. Run the Docker container with environment variables:
+```bash
+docker run -p 3000:3000 \
+  -e GITHUB_TOKEN="your_github_token" \
+  -e GITHUB_ENTERPRISE_URL="https://github.your-company.com/api/v3" \
+  -e DEBUG=true \
+  github-enterprise-mcp
+```
+
+> **Note**: The Dockerfile is configured to run with `--transport http` by default. If you need to change this, you can override the command:
+```bash
+docker run -p 3000:3000 \
+  -e GITHUB_TOKEN="your_github_token" \
+  -e GITHUB_ENTERPRISE_URL="https://github.your-company.com/api/v3" \
+  -e DEBUG=true \
+  github-enterprise-mcp node dist/index.js --transport http --debug
+```
+
+#### Option 2: Using Docker Compose
+
+1. Create a `.env` file in the project root with the required environment variables:
+```
+GITHUB_ENTERPRISE_URL=https://github.your-company.com/api/v3
+GITHUB_TOKEN=your_github_token
+DEBUG=true
+```
+
+2. Start the container with Docker Compose:
+```bash
+docker-compose up -d
+```
+
+3. Check the logs:
+```bash
+docker-compose logs -f
+```
+
+4. Stop the container:
+```bash
+docker-compose down
+```
 
 ### Installation and Setup
 
@@ -216,10 +268,10 @@ This MCP server provides the following tools:
 | `list-workflows` | List GitHub Actions workflows | `owner`: Repository owner<br>`repo`: Repository name<br>`page`: Page number<br>`perPage`: Items per page | `actions:read` |
 | `list-workflow-runs` | List workflow runs | `owner`: Repository owner<br>`repo`: Repository name<br>`workflow_id`: Workflow ID/filename<br>`branch`: Filter by branch<br>`status`: Filter by status<br>`page`: Page number<br>`perPage`: Items per page | `actions:read` |
 | `trigger-workflow` | Trigger a workflow | `owner`: Repository owner<br>`repo`: Repository name<br>`workflow_id`: Workflow ID/filename<br>`ref`: Git reference<br>`inputs`: Workflow inputs | `actions:write` |
-| `get-license-info` | Get GitHub Enterprise license information **(Requires Classic PAT)** | - | `admin:enterprise` |
-| `get-enterprise-stats` | Get GitHub Enterprise system statistics **(Requires Classic PAT)** | - | `admin:enterprise` |
+| `get-license-info` | Get GitHub Enterprise license information | - | **Requires site_admin (Administrator) account** |
+| `get-enterprise-stats` | Get GitHub Enterprise system statistics | - | **Requires site_admin (Administrator) account** |
 
-> **Note**: For Enterprise-specific tools (`get-license-info` and `get-enterprise-stats`), a **Classic Personal Access Token** with `admin:enterprise` scope is required. Fine-grained tokens do not support these Enterprise-level permissions.
+> **Note**: For Enterprise-specific tools (`get-license-info` and `get-enterprise-stats`), a user with **site administrator** privileges is required. A Classic Personal Access Token is recommended, as Fine-grained tokens may not support these Enterprise-level permissions.
 
 ## Using the Tools in Cursor
 
@@ -286,6 +338,45 @@ mcp_github_enterprise_update_repository(
   description="Updated description",
   has_issues=true
 )
+```
+
+### User Management (Enterprise Only)
+
+These features are specifically designed for GitHub Enterprise Server environments and require administrative permissions:
+
+```
+# List all users in the GitHub Enterprise instance
+mcp_github_enterprise_list_users(filter="active", per_page=100)
+
+# Get a specific user's details
+mcp_github_enterprise_get_user(username="octocat")
+
+# Create a new user (Enterprise only)
+mcp_github_enterprise_create_user(
+  login="newuser",
+  email="newuser@example.com",
+  name="New User",
+  company="ACME Inc."
+)
+
+# Update a user's information (Enterprise only)
+mcp_github_enterprise_update_user(
+  username="octocat",
+  email="updated-email@example.com",
+  location="San Francisco"
+)
+
+# Suspend a user (Enterprise only)
+mcp_github_enterprise_suspend_user(
+  username="octocat",
+  reason="Violation of terms of service"
+)
+
+# Unsuspend a user (Enterprise only)
+mcp_github_enterprise_unsuspend_user(username="octocat")
+
+# List organizations a user belongs to
+mcp_github_enterprise_list_user_orgs(username="octocat")
 ```
 
 ## API Improvements

--- a/api/users/types.ts
+++ b/api/users/types.ts
@@ -1,0 +1,222 @@
+/**
+ * GitHub Enterprise User Management API Type Definitions
+ * 
+ * This file contains type definitions for the GitHub Enterprise User Management API.
+ */
+
+/**
+ * User type definition representing a GitHub Enterprise user
+ */
+export interface User {
+  login: string;
+  id: number;
+  node_id: string;
+  avatar_url: string;
+  gravatar_id: string;
+  url: string;
+  html_url: string;
+  followers_url: string;
+  following_url: string;
+  gists_url: string;
+  starred_url: string;
+  subscriptions_url: string;
+  organizations_url: string;
+  repos_url: string;
+  events_url: string;
+  received_events_url: string;
+  type: string;
+  site_admin: boolean;
+  name?: string;
+  company?: string;
+  blog?: string;
+  location?: string;
+  email?: string;
+  hireable?: boolean;
+  bio?: string;
+  twitter_username?: string;
+  public_repos?: number;
+  public_gists?: number;
+  followers?: number;
+  following?: number;
+  created_at?: string;
+  updated_at?: string;
+  suspended?: boolean;
+  private_gists?: number;
+  total_private_repos?: number;
+  owned_private_repos?: number;
+  disk_usage?: number;
+  collaborators?: number;
+  two_factor_authentication?: boolean;
+  plan?: {
+    name: string;
+    space: number;
+    private_repos: number;
+    collaborators: number;
+  };
+}
+
+/**
+ * Parameters to list users in GitHub Enterprise
+ */
+export interface ListUsersParams {
+  /**
+   * Optional number of results per page (max 100)
+   */
+  per_page?: number;
+  
+  /**
+   * Optional page number for pagination
+   */
+  page?: number;
+  
+  /**
+   * Optional parameter to filter users based on their activity
+   * - all: Every user, regardless of activity status
+   * - active: Only users who are active
+   * - suspended: Only users who have been suspended
+   */
+  filter?: 'all' | 'active' | 'suspended';
+  
+  /**
+   * Optional search query to filter users by username or email
+   */
+  search?: string;
+}
+
+/**
+ * Parameters to get a specific user by their username
+ */
+export interface GetUserParams {
+  /**
+   * Username of the user to retrieve
+   */
+  username: string;
+}
+
+/**
+ * Parameters to create a new enterprise user
+ */
+export interface CreateUserParams {
+  /**
+   * The username for the user
+   */
+  login: string;
+  
+  /**
+   * The email address for the user
+   */
+  email: string;
+  
+  /**
+   * Optional full name for the user
+   */
+  name?: string;
+  
+  /**
+   * Optional company for the user
+   */
+  company?: string;
+  
+  /**
+   * Optional location for the user
+   */
+  location?: string;
+  
+  /**
+   * Optional biography for the user
+   */
+  bio?: string;
+  
+  /**
+   * Optional URL of the user's blog or website
+   */
+  blog?: string;
+  
+  /**
+   * Optional Twitter username for the user
+   */
+  twitter_username?: string;
+}
+
+/**
+ * Parameters to update an existing user
+ */
+export interface UpdateUserParams extends Partial<CreateUserParams> {
+  /**
+   * Username of the user to update
+   */
+  username: string;
+}
+
+/**
+ * Parameters to delete a user
+ */
+export interface DeleteUserParams {
+  /**
+   * Username of the user to delete
+   */
+  username: string;
+}
+
+/**
+ * Parameters to suspend a user
+ */
+export interface SuspendUserParams {
+  /**
+   * Username of the user to suspend
+   */
+  username: string;
+  
+  /**
+   * Optional reason for the suspension
+   */
+  reason?: string;
+}
+
+/**
+ * Parameters to unsuspend a user
+ */
+export interface UnsuspendUserParams {
+  /**
+   * Username of the user to unsuspend
+   */
+  username: string;
+}
+
+/**
+ * Parameters to list the organizations a user belongs to
+ */
+export interface ListUserOrgsParams {
+  /**
+   * Username of the user whose organizations to list
+   */
+  username: string;
+  
+  /**
+   * Optional number of results per page (max 100)
+   */
+  per_page?: number;
+  
+  /**
+   * Optional page number for pagination
+   */
+  page?: number;
+}
+
+/**
+ * Organization type definition representing a GitHub organization
+ */
+export interface Organization {
+  login: string;
+  id: number;
+  node_id: string;
+  url: string;
+  repos_url: string;
+  events_url: string;
+  hooks_url: string;
+  issues_url: string;
+  members_url: string;
+  public_members_url: string;
+  avatar_url: string;
+  description: string;
+} 

--- a/api/users/users.ts
+++ b/api/users/users.ts
@@ -1,0 +1,363 @@
+/**
+ * GitHub Enterprise User Management API
+ * 
+ * This file contains the implementation of the GitHub Enterprise User Management API.
+ * It provides functionality for managing users in a GitHub Enterprise environment.
+ */
+
+import axios from 'axios';
+import { 
+  User, 
+  ListUsersParams, 
+  GetUserParams, 
+  CreateUserParams, 
+  UpdateUserParams, 
+  DeleteUserParams, 
+  SuspendUserParams, 
+  UnsuspendUserParams,
+  ListUserOrgsParams,
+  Organization 
+} from './types.js';
+
+/**
+ * User Management API Class
+ * 
+ * Provides methods for managing users in GitHub Enterprise
+ */
+export class UserManagement {
+  /**
+   * List all users in the GitHub Enterprise instance
+   * 
+   * @param client - GitHub API client
+   * @param params - Parameters for listing users
+   * @returns Promise that resolves to an array of User objects
+   */
+  async listUsers(client: any, params?: ListUsersParams): Promise<User[]> {
+    try {
+      const { baseUrl, token } = client;
+      
+      if (!baseUrl) {
+        throw new Error('GitHub Enterprise URL is not set');
+      }
+      
+      if (!token) {
+        throw new Error('GitHub token is not set');
+      }
+      
+      const queryParams = new URLSearchParams();
+      
+      if (params?.per_page) {
+        queryParams.append('per_page', params.per_page.toString());
+      }
+      
+      if (params?.page) {
+        queryParams.append('page', params.page.toString());
+      }
+      
+      if (params?.filter) {
+        queryParams.append('filter', params.filter);
+      }
+      
+      if (params?.search) {
+        queryParams.append('q', params.search);
+      }
+      
+      const queryString = queryParams.toString() ? `?${queryParams.toString()}` : '';
+      
+      // For GitHub Enterprise, we use the admin API endpoint for user management
+      // This endpoint is only available to site administrators
+      const url = `${baseUrl}/admin/users${queryString}`;
+      
+      console.log('Requesting users from URL:', url);
+      
+      const response = await axios.get(url, {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github.v3+json'
+        }
+      });
+      
+      return response.data;
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        throw new Error('User listing endpoint not found. Make sure you have admin permissions and are using GitHub Enterprise.');
+      }
+      
+      if (error.response?.status === 403) {
+        throw new Error('Access forbidden. This endpoint requires site administrator permissions.');
+      }
+      
+      if (error.response) {
+        throw new Error(`Failed to list users: ${error.response.status} ${error.response.statusText}`);
+      }
+      
+      throw new Error(`Failed to list users: ${error.message}`);
+    }
+  }
+  
+  /**
+   * Get a specific user by username
+   * 
+   * @param client - GitHub API client
+   * @param params - Parameters with username
+   * @returns Promise that resolves to a User object
+   */
+  async getUser(client: any, params: GetUserParams): Promise<User> {
+    try {
+      const { baseUrl, token } = client;
+      const { username } = params;
+      
+      if (!username) {
+        throw new Error('Username is required');
+      }
+      
+      const url = `${baseUrl}/users/${username}`;
+      
+      const response = await axios.get(url, {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github.v3+json'
+        }
+      });
+      
+      return response.data;
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        throw new Error(`User '${params.username}' not found`);
+      }
+      
+      throw new Error(`Failed to get user: ${error.message}`);
+    }
+  }
+  
+  /**
+   * Create a new user in GitHub Enterprise
+   * Note: This is only available in GitHub Enterprise
+   * 
+   * @param client - GitHub API client
+   * @param params - Parameters for creating a user
+   * @returns Promise that resolves to the created User object
+   */
+  async createUser(client: any, params: CreateUserParams): Promise<User> {
+    try {
+      const { baseUrl, token } = client;
+      
+      if (!params.login || !params.email) {
+        throw new Error('Username (login) and email are required');
+      }
+      
+      const url = `${baseUrl}/admin/users`;
+      
+      const response = await axios.post(url, params, {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github.v3+json',
+          'Content-Type': 'application/json'
+        }
+      });
+      
+      return response.data;
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        throw new Error('User creation endpoint not found. Make sure you have admin permissions and are using GitHub Enterprise.');
+      } else if (error.response?.status === 422) {
+        throw new Error(`Validation failed: ${error.response.data.message || 'Check the username and email format'}`);
+      }
+      
+      throw new Error(`Failed to create user: ${error.message}`);
+    }
+  }
+  
+  /**
+   * Update an existing user in GitHub Enterprise
+   * 
+   * @param client - GitHub API client
+   * @param params - Parameters for updating a user
+   * @returns Promise that resolves to the updated User object
+   */
+  async updateUser(client: any, params: UpdateUserParams): Promise<User> {
+    try {
+      const { baseUrl, token } = client;
+      const { username, ...userData } = params;
+      
+      if (!username) {
+        throw new Error('Username is required');
+      }
+      
+      const url = `${baseUrl}/admin/users/${username}`;
+      
+      const response = await axios.patch(url, userData, {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github.v3+json',
+          'Content-Type': 'application/json'
+        }
+      });
+      
+      return response.data;
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        throw new Error(`User '${params.username}' not found or admin endpoint not available`);
+      } else if (error.response?.status === 422) {
+        throw new Error(`Validation failed: ${error.response.data.message || 'Check the provided data format'}`);
+      }
+      
+      throw new Error(`Failed to update user: ${error.message}`);
+    }
+  }
+  
+  /**
+   * Delete a user from GitHub Enterprise
+   * 
+   * @param client - GitHub API client
+   * @param params - Parameters with username to delete
+   * @returns Promise that resolves to true if successful
+   */
+  async deleteUser(client: any, params: DeleteUserParams): Promise<boolean> {
+    try {
+      const { baseUrl, token } = client;
+      const { username } = params;
+      
+      if (!username) {
+        throw new Error('Username is required');
+      }
+      
+      const url = `${baseUrl}/admin/users/${username}`;
+      
+      await axios.delete(url, {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github.v3+json'
+        }
+      });
+      
+      return true;
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        throw new Error(`User '${params.username}' not found or admin endpoint not available`);
+      }
+      
+      throw new Error(`Failed to delete user: ${error.message}`);
+    }
+  }
+  
+  /**
+   * Suspend a user in GitHub Enterprise
+   * 
+   * @param client - GitHub API client
+   * @param params - Parameters with username to suspend
+   * @returns Promise that resolves to true if successful
+   */
+  async suspendUser(client: any, params: SuspendUserParams): Promise<boolean> {
+    try {
+      const { baseUrl, token } = client;
+      const { username, reason } = params;
+      
+      if (!username) {
+        throw new Error('Username is required');
+      }
+      
+      const url = `${baseUrl}/admin/users/${username}/suspended`;
+      
+      // If a reason is provided, include it in the request body
+      const data = reason ? { reason } : {};
+      
+      await axios.put(url, data, {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github.v3+json',
+          'Content-Type': 'application/json'
+        }
+      });
+      
+      return true;
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        throw new Error(`User '${params.username}' not found or admin endpoint not available`);
+      }
+      
+      throw new Error(`Failed to suspend user: ${error.message}`);
+    }
+  }
+  
+  /**
+   * Unsuspend a user in GitHub Enterprise
+   * 
+   * @param client - GitHub API client
+   * @param params - Parameters with username to unsuspend
+   * @returns Promise that resolves to true if successful
+   */
+  async unsuspendUser(client: any, params: UnsuspendUserParams): Promise<boolean> {
+    try {
+      const { baseUrl, token } = client;
+      const { username } = params;
+      
+      if (!username) {
+        throw new Error('Username is required');
+      }
+      
+      const url = `${baseUrl}/admin/users/${username}/suspended`;
+      
+      await axios.delete(url, {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github.v3+json'
+        }
+      });
+      
+      return true;
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        throw new Error(`User '${params.username}' not found or admin endpoint not available`);
+      }
+      
+      throw new Error(`Failed to unsuspend user: ${error.message}`);
+    }
+  }
+  
+  /**
+   * List organizations a user belongs to
+   * 
+   * @param client - GitHub API client
+   * @param params - Parameters with username and pagination options
+   * @returns Promise that resolves to an array of Organization objects
+   */
+  async listUserOrganizations(client: any, params: ListUserOrgsParams): Promise<Organization[]> {
+    try {
+      const { baseUrl, token } = client;
+      const { username, per_page, page } = params;
+      
+      if (!username) {
+        throw new Error('Username is required');
+      }
+      
+      const queryParams = new URLSearchParams();
+      
+      if (per_page) {
+        queryParams.append('per_page', per_page.toString());
+      }
+      
+      if (page) {
+        queryParams.append('page', page.toString());
+      }
+      
+      const queryString = queryParams.toString() ? `?${queryParams.toString()}` : '';
+      const url = `${baseUrl}/users/${username}/orgs${queryString}`;
+      
+      const response = await axios.get(url, {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github.v3+json'
+        }
+      });
+      
+      return response.data;
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        throw new Error(`User '${params.username}' not found`);
+      }
+      
+      throw new Error(`Failed to list user organizations: ${error.message}`);
+    }
+  }
+} 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -9,3 +9,5 @@ export * from './api/issues/issues.js';
 export * from './api/issues/types.js';
 export * from './api/actions/actions.js';
 export * from './api/actions/types.js';
+export * from './api/users/users.js';
+export * from './api/users/types.js';

--- a/dist/index.js
+++ b/dist/index.js
@@ -16,6 +16,9 @@ export * from './api/issues/types.js';
 // Re-export actions API
 export * from './api/actions/actions.js';
 export * from './api/actions/types.js';
+// Re-export users API
+export * from './api/users/users.js';
+export * from './api/users/types.js';
 // Default CLI entry point
 // ES 모듈 환경에서 실행 여부 확인 - NPX 환경 포함
 const isDirectRun = process.argv[1] === import.meta.url ||

--- a/dist/server/index.d.ts
+++ b/dist/server/index.d.ts
@@ -5,6 +5,7 @@ import { AdminAPI } from '../api/admin/admin.js';
 import { ActionsAPI } from '../api/actions/actions.js';
 import * as PullsAPI from '../api/pulls/pulls.js';
 import * as IssuesAPI from '../api/issues/issues.js';
+import { UserManagement } from '../api/users/users.js';
 export interface GitHubContext {
     client: GitHubClient;
     repository: RepositoryAPI;
@@ -12,6 +13,8 @@ export interface GitHubContext {
     actions: ActionsAPI;
     pulls: typeof PullsAPI;
     issues: typeof IssuesAPI;
+    users: UserManagement;
+    isGitHubEnterprise: boolean;
 }
 export interface GitHubServerOptions {
     config?: Partial<Config>;

--- a/dist/server/index.js
+++ b/dist/server/index.js
@@ -9,6 +9,7 @@ import { ActionsAPI } from '../api/actions/actions.js';
 import * as PullsAPI from '../api/pulls/pulls.js';
 import * as IssuesAPI from '../api/issues/issues.js';
 import { startHttpServer } from './http.js';
+import { UserManagement } from '../api/users/users.js';
 /**
  * Convert repository information to user-friendly format
  */
@@ -140,7 +141,9 @@ export async function startServer(options = {}) {
         admin,
         actions,
         pulls,
-        issues
+        issues,
+        users: new UserManagement(),
+        isGitHubEnterprise: !!config.baseUrl && !config.baseUrl.includes('github.com')
     };
     // Create MCP server
     const server = new McpServer({
@@ -1445,6 +1448,325 @@ export async function startServer(options = {}) {
                     {
                         type: "text",
                         text: `이슈를 생성하는 중 오류가 발생했습니다: ${error.message}`
+                    }
+                ],
+                isError: true
+            };
+        }
+    });
+    // User management tools
+    server.tool("list-users", {
+        per_page: z.number().optional().describe("Number of results per page (max 100)"),
+        page: z.number().optional().describe("Page number for pagination"),
+        filter: z.enum(['all', 'active', 'suspended']).optional().describe("Filter users by status"),
+        search: z.string().optional().describe("Search query to filter users by username or email")
+    }, async ({ per_page, page, filter, search }) => {
+        try {
+            const users = await context.users.listUsers(context.client, {
+                per_page,
+                page,
+                filter,
+                search
+            });
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `GitHub Enterprise users list:\n\n${JSON.stringify(users, null, 2)}`
+                    }
+                ]
+            };
+        }
+        catch (error) {
+            console.error('Error listing users:', error);
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `An error occurred while retrieving users list: ${error.message}`
+                    }
+                ],
+                isError: true
+            };
+        }
+    });
+    server.tool("get-user", {
+        username: z.string().describe("Username of the user to retrieve")
+    }, async ({ username }) => {
+        try {
+            const user = await context.users.getUser(context.client, { username });
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `User details for '${username}':\n\n${JSON.stringify(user, null, 2)}`
+                    }
+                ]
+            };
+        }
+        catch (error) {
+            console.error('Error getting user details:', error);
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `An error occurred while retrieving user details: ${error.message}`
+                    }
+                ],
+                isError: true
+            };
+        }
+    });
+    server.tool("create-user", {
+        login: z.string().describe("The username for the user"),
+        email: z.string().describe("The email address for the user"),
+        name: z.string().optional().describe("Full name for the user"),
+        company: z.string().optional().describe("Company for the user"),
+        location: z.string().optional().describe("Location for the user"),
+        bio: z.string().optional().describe("Biography for the user"),
+        blog: z.string().optional().describe("URL of the user's blog or website"),
+        twitter_username: z.string().optional().describe("Twitter username for the user")
+    }, async ({ login, email, name, company, location, bio, blog, twitter_username }) => {
+        try {
+            if (!context.isGitHubEnterprise) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: "User creation is only available in GitHub Enterprise. This operation cannot be performed on GitHub.com."
+                        }
+                    ],
+                    isError: true
+                };
+            }
+            const user = await context.users.createUser(context.client, {
+                login,
+                email,
+                name,
+                company,
+                location,
+                bio,
+                blog,
+                twitter_username
+            });
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `User '${login}' successfully created:\n\n${JSON.stringify(user, null, 2)}`
+                    }
+                ]
+            };
+        }
+        catch (error) {
+            console.error('Error creating user:', error);
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `An error occurred while creating user: ${error.message}`
+                    }
+                ],
+                isError: true
+            };
+        }
+    });
+    server.tool("update-user", {
+        username: z.string().describe("Username of the user to update"),
+        email: z.string().optional().describe("The email address for the user"),
+        name: z.string().optional().describe("Full name for the user"),
+        company: z.string().optional().describe("Company for the user"),
+        location: z.string().optional().describe("Location for the user"),
+        bio: z.string().optional().describe("Biography for the user"),
+        blog: z.string().optional().describe("URL of the user's blog or website"),
+        twitter_username: z.string().optional().describe("Twitter username for the user")
+    }, async ({ username, email, name, company, location, bio, blog, twitter_username }) => {
+        try {
+            if (!context.isGitHubEnterprise) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: "User updates are only available in GitHub Enterprise. This operation cannot be performed on GitHub.com."
+                        }
+                    ],
+                    isError: true
+                };
+            }
+            const user = await context.users.updateUser(context.client, {
+                username,
+                email,
+                name,
+                company,
+                location,
+                bio,
+                blog,
+                twitter_username
+            });
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `User '${username}' successfully updated:\n\n${JSON.stringify(user, null, 2)}`
+                    }
+                ]
+            };
+        }
+        catch (error) {
+            console.error('Error updating user:', error);
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `An error occurred while updating user: ${error.message}`
+                    }
+                ],
+                isError: true
+            };
+        }
+    });
+    server.tool("delete-user", {
+        username: z.string().describe("Username of the user to delete")
+    }, async ({ username }) => {
+        try {
+            if (!context.isGitHubEnterprise) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: "User deletion is only available in GitHub Enterprise. This operation cannot be performed on GitHub.com."
+                        }
+                    ],
+                    isError: true
+                };
+            }
+            await context.users.deleteUser(context.client, { username });
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `User '${username}' has been successfully deleted.`
+                    }
+                ]
+            };
+        }
+        catch (error) {
+            console.error('Error deleting user:', error);
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `An error occurred while deleting user: ${error.message}`
+                    }
+                ],
+                isError: true
+            };
+        }
+    });
+    server.tool("suspend-user", {
+        username: z.string().describe("Username of the user to suspend"),
+        reason: z.string().optional().describe("Reason for the suspension")
+    }, async ({ username, reason }) => {
+        try {
+            if (!context.isGitHubEnterprise) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: "User suspension is only available in GitHub Enterprise. This operation cannot be performed on GitHub.com."
+                        }
+                    ],
+                    isError: true
+                };
+            }
+            await context.users.suspendUser(context.client, { username, reason });
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `User '${username}' has been suspended.${reason ? ` Reason: ${reason}` : ''}`
+                    }
+                ]
+            };
+        }
+        catch (error) {
+            console.error('Error suspending user:', error);
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `An error occurred while suspending user: ${error.message}`
+                    }
+                ],
+                isError: true
+            };
+        }
+    });
+    server.tool("unsuspend-user", {
+        username: z.string().describe("Username of the user to unsuspend")
+    }, async ({ username }) => {
+        try {
+            if (!context.isGitHubEnterprise) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: "User unsuspension is only available in GitHub Enterprise. This operation cannot be performed on GitHub.com."
+                        }
+                    ],
+                    isError: true
+                };
+            }
+            await context.users.unsuspendUser(context.client, { username });
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `User '${username}' has been unsuspended.`
+                    }
+                ]
+            };
+        }
+        catch (error) {
+            console.error('Error unsuspending user:', error);
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `An error occurred while unsuspending user: ${error.message}`
+                    }
+                ],
+                isError: true
+            };
+        }
+    });
+    server.tool("list-user-orgs", {
+        username: z.string().describe("Username of the user whose organizations to list"),
+        per_page: z.number().optional().describe("Number of results per page (max 100)"),
+        page: z.number().optional().describe("Page number for pagination")
+    }, async ({ username, per_page, page }) => {
+        try {
+            const orgs = await context.users.listUserOrganizations(context.client, {
+                username,
+                per_page,
+                page
+            });
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `Organizations for user '${username}':\n\n${JSON.stringify(orgs, null, 2)}`
+                    }
+                ]
+            };
+        }
+        catch (error) {
+            console.error('Error listing user organizations:', error);
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `An error occurred while listing user organizations: ${error.message}`
                     }
                 ],
                 isError: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+services:
+  github-enterprise-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    command: ["node", "dist/index.js", "--transport", "http"]
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - GITHUB_ENTERPRISE_URL=${GITHUB_ENTERPRISE_URL}
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - REQUEST_TIMEOUT=${REQUEST_TIMEOUT:-10000}
+      - DEBUG=${DEBUG:-false}
+    restart: unless-stopped
+    volumes:
+      - ./.env:/app/.env:ro 

--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,10 @@ export * from './api/issues/types.js';
 export * from './api/actions/actions.js';
 export * from './api/actions/types.js';
 
+// Re-export users API
+export * from './api/users/users.js';
+export * from './api/users/types.js';
+
 // Default CLI entry point
 // ES 모듈 환경에서 실행 여부 확인 - NPX 환경 포함
 const isDirectRun = process.argv[1] === import.meta.url || 


### PR DESCRIPTION
## Description
This PR adds Docker support to the GitHub Enterprise MCP project, making it easier to deploy and run in containerized environments. It also corrects the documentation regarding the permissions required for enterprise-specific tools.

## Changes
- Added Dockerfile using Node.js 18 Alpine as the base image
- Created .dockerignore to exclude unnecessary files from the Docker build
- Added docker-compose.yml for simplified deployment
- Configured the application to run in HTTP/SSE transport mode by default
- Updated README with comprehensive Docker installation and usage instructions
- Corrected documentation for enterprise-specific tools (get-license-info, get-enterprise-stats) to clarify that site_admin privileges are required

## Testing
The Docker setup has been tested with GitHub Enterprise Server, confirming that:
- The container builds successfully and runs as expected
- The application connects to GitHub Enterprise API properly
- Enterprise features work correctly with site_admin permissions

## Note
For enterprise-specific features (license info, statistics), a site administrator account's token is required, regardless of the token scopes assigned.