### PR TITLE
Potential fix for code scanning alert no. 6: Type confusion through parameter tampering

### DIFF
--- a/server/http.ts
+++ b/server/http.ts
@@ -102,16 +102,16 @@ export async function startHttpServer(server: McpServer, port: number = 3000): P
   app.post('/messages', async (req: Request, res: Response) => {
     try {
       // Extract session ID from query string and clean it
-      let sessionId = req.query.sessionId as string;
+      let sessionId = req.query.sessionId;
       
-      if (!sessionId) {
-        console.error('No session ID provided');
+      if (!sessionId || typeof sessionId !== 'string') {
+        console.error('Invalid or no session ID provided');
         return res.status(400).json({
           jsonrpc: '2.0',
           id: null,
           error: {
             code: -32602,
-            message: 'Session ID required'
+            message: 'Valid session ID required'
           }
         });
       }


### PR DESCRIPTION
Potential fix for [https://github.com/ddukbg/github-enterprise-mcp/security/code-scanning/6](https://github.com/ddukbg/github-enterprise-mcp/security/code-scanning/6)

To fix the problem, we need to ensure that `sessionId` is a string before performing any operations on it. This can be done by adding a type check for `sessionId` and handling the case where it is not a string. Specifically, we should check if `sessionId` is an array and handle it appropriately, such as by returning an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
